### PR TITLE
Add switch to keywords list that uses Allman braces style

### DIFF
--- a/Sniffs/ControlStructures/AllmanControlSignatureSniff.php
+++ b/Sniffs/ControlStructures/AllmanControlSignatureSniff.php
@@ -35,6 +35,7 @@ class GiantRobot_Sniffs_ControlStructures_AllmanControlSignatureSniff implements
             T_FOREACH,
             T_ELSE,
             T_ELSEIF,
+            T_SWITCH,
         );
     }
 


### PR DESCRIPTION
Updated `switch` curly braces style to Allman.

`switch` statement used to be indented in K&R style:

```
switch ($var) {
}
```

Now it is indented in Allman style:

```
switch ($var)
{
}
```
